### PR TITLE
Fix tests/github actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,9 +14,6 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8, 3.9, '3.10', '3.11']
-                include:
-                    - python-version: '3.7'
-                      os: ubuntu-20.04
         steps:
             -   uses: actions/checkout@v2
             -   name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,10 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+                python-version: [3.8, 3.9, '3.10', '3.11']
+                include:
+                    - python-version: '3.7'
+                      os: ubuntu-20.04
         steps:
             -   uses: actions/checkout@v2
             -   name: Set up Python ${{ matrix.python-version }}
@@ -24,7 +27,7 @@ jobs:
                 run: python -m pip install --upgrade pip setuptools wheel
 
             -   name: Install development dependencies
-                run: pip install flake8 pytest pytest-cov scipy
+                run: pip install -r requirements-dev.txt
             -   name: Lint with flake8
                 run: |
                     # stop the build if there are Python syntax errors or undefined names
@@ -37,7 +40,7 @@ jobs:
                 run: |
                     pytest tests.py --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=com --cov-report=xml --cov-report=html
             -   name: Upload pytest test results
-                uses: actions/upload-artifact@v1
+                uses: actions/upload-artifact@v6
                 with:
                     name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
                     path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,7 @@
 numpy
+scipy
 sphinx
 sphinx-rtd-theme
+flake8
 pytest
+pytest-cov


### PR DESCRIPTION
Test fixes
----
I noticed the github actions for this repo were failing, so I made some changes to get them to pass:

- use newer artifact upload version: v1 is deprecated, changed to v6
- updated `requirements-dev.txt` to include the required test dependencies (scipy, flake8, pytest-cov)
- the actions now installs requirements from `requirements-dev.txt` instead of hard-coding the dependencies in the github actions file
- python 3.7 is end of life - it wont work with github actions on ubuntu-latest. I've changed this to only run with python 3.7 on ubuntu 20.04, but another option would be to just not run with python 3.7 entirely (it takes ages to find a github actions runner on ubuntu 20.04)