### PR TITLE
Faster normalisation by vectorising the python loops

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
     push:
-        branches: [ master, develop, faster_normalise ]
+        branches: [ master, develop ]
     pull_request:
         branches: [ master, develop ]
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
     push:
-        branches: [ master, develop, faster_normalise ]
+        branches: [ master, develop ]
     pull_request:
         branches: [ master, develop ]
 
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.8, 3.9, '3.10', '3.11']
+                python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         steps:
             -   uses: actions/checkout@v2
             -   name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +37,7 @@ jobs:
                 run: |
                     pytest tests.py --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=com --cov-report=xml --cov-report=html
             -   name: Upload pytest test results
-                uses: actions/upload-artifact@v6
+                uses: actions/upload-artifact@v1
                 with:
                     name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
                     path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+                python-version: [3.8, 3.9, '3.10', '3.11']
         steps:
             -   uses: actions/checkout@v2
             -   name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +37,7 @@ jobs:
                 run: |
                     pytest tests.py --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=com --cov-report=xml --cov-report=html
             -   name: Upload pytest test results
-                uses: actions/upload-artifact@v1
+                uses: actions/upload-artifact@v6
                 with:
                     name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
                     path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
     push:
-        branches: [ master, develop ]
+        branches: [ master, develop, faster_normalise ]
     pull_request:
         branches: [ master, develop ]
 

--- a/pyefd.py
+++ b/pyefd.py
@@ -112,21 +112,25 @@ def normalize_efd(coeffs, size_invariant=True, return_transformation=False):
         ),
     )
     # Rotate all coefficients by theta_1.
-    for n in _range(1, coeffs.shape[0] + 1):
-        coeffs[n - 1, :] = np.dot(
-            np.array(
-                [
-                    [coeffs[n - 1, 0], coeffs[n - 1, 1]],
-                    [coeffs[n - 1, 2], coeffs[n - 1, 3]],
-                ]
-            ),
-            np.array(
-                [
-                    [np.cos(n * theta_1), -np.sin(n * theta_1)],
-                    [np.sin(n * theta_1), np.cos(n * theta_1)],
-                ]
-            ),
-        ).flatten()
+    # Reshape the coefficients from a shape (N, 4) array into
+    # an (N, 2, 2) array - i.e. N 2x2 matrices
+    coeff_matrices = coeffs.reshape(-1, 2, 2)
+
+    # We want to rotate the first harmonic by theta_1, the second by 2*theta_1 etc.
+    # We can define an array of rotation matrices and then use numpy vector
+    # operations to rotate all of our 2x2 coefficient matrices in a vectorised way
+    indices = np.arange(1, coeffs.shape[0] + 1)  # 1, 2, 3, ..., N
+    cos, sin = np.cos(indices * theta_1), np.sin(indices * theta_1)
+    theta_rotations = np.stack(
+        [
+            np.stack([cos, -sin], axis=1),
+            np.stack([sin, cos], axis=1),
+        ],
+        axis=1,
+    )
+    coeff_matrices = np.matmul(coeff_matrices, theta_rotations)
+    coeffs = coeff_matrices.reshape(-1, 4)
+
 
     # Make the coefficients rotation invariant by rotating so that
     # the semi-major axis is parallel to the x-axis.

--- a/pyefd.py
+++ b/pyefd.py
@@ -139,15 +139,7 @@ def normalize_efd(coeffs, size_invariant=True, return_transformation=False):
         [[np.cos(psi_1), np.sin(psi_1)], [-np.sin(psi_1), np.cos(psi_1)]]
     )
     # Rotate all coefficients by -psi_1.
-    for n in _range(1, coeffs.shape[0] + 1):
-        coeffs[n - 1, :] = psi_rotation_matrix.dot(
-            np.array(
-                [
-                    [coeffs[n - 1, 0], coeffs[n - 1, 1]],
-                    [coeffs[n - 1, 2], coeffs[n - 1, 3]],
-                ]
-            )
-        ).flatten()
+    coeffs = np.matmul(psi_rotation_matrix, coeffs.reshape(-1, 2, 2)).reshape(-1, 4)
 
     size = coeffs[0, 0]
     if size_invariant:


### PR DESCRIPTION
At the moment the rotations in the normalisation happen in python loops, which could be sped up with numpy operations.

We have two rotations:
1. rotating all the harmonics by n*theta to remove a phase ambiguity
2.  rotating everything rigidly so that the major axis lies along the x-axis

I've replaced the python loops with numpy operations:
1.
- reshape the Nx4 coefficient array to Nx2x2 (i.e. N 2x2 matrices of (a, b), (c, d))
- make another Nx2x2 shaped array holding our rotation matrices
- multiply them together

2.
- use numpy to rotate by the psi rotation matrix

It's slightly faster: it't not noticable if you do a single expansion with a few harmonics, but it's noticable if you're using very many harmonics or are finding the EFD coefficients for a lot of shapes.

I did some simple profiling of `pyefd.elliptic_fourier_descriptors(contour, normalize=True)` using the bean example; the function call is around 2x as fast if we have 1000 harmonics.

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/8cd39a78-cdf3-4342-9c76-b117d5b38728" />
